### PR TITLE
Remove animation from progress bar in case user has "Reduced motion" turned on

### DIFF
--- a/packages/u-progress/u-progress.ts
+++ b/packages/u-progress/u-progress.ts
@@ -32,8 +32,9 @@ export class UHTMLProgressElement extends UHTMLElement {
       createElement('style', {
         textContent: `:host(:not([hidden])) { box-sizing: border-box; border: 1px solid; display: inline-block; height: .5em; width: 10em; overflow: hidden }
         :host::before { content: ''; display: block; height: 100%; background: currentColor; width: var(--percentage, 0%); transition: width .2s }
-        :host(:not([value])) { animation: indeterminate 2s linear infinite; background: linear-gradient(90deg,currentColor 25%, transparent 50%, currentColor 75%) 100%/400% }
-        @keyframes indeterminate { to { background-position-x: 0 } }`
+        :host { --empty-bg: linear-gradient(90deg,currentColor 25%, transparent 50%, currentColor 75%) 100%/400%; }
+        @media (prefers-reduced-motion: no-preference) { :host(:not([value])) { animation: indeterminate 2s linear infinite; background: var(--empty-bg); } @keyframes indeterminate { to { background-position-x: 0 } } }
+        @media (prefers-reduced-motion: reduce) { :host(:not([value])) { background: var(--empty-bg)} }`
       })
     )
     this.attributeChangedCallback() // We now know the element is in the DOM, so run a attribute setup


### PR DESCRIPTION
Didn't see a contribution guide, but hopefully it's adequate!

Tried to change the test spec to account for this, but setting up the context and page setup required to emulate prefers-reduced-motion seemed a bit too intrusive for this case.

-Use @media query for checking users preference.
  - If no preference: show animation
  - If preference == reduce: remove animation
  - Either way, set background to the linear-gradient in case the progress bar is empty. Maybe this should be currentColor if it's empty and reduced motion is on? 