### PR TITLE
U tabs: debug svelte - aria-selected bug

### DIFF
--- a/frameworks/svelte/App.svelte
+++ b/frameworks/svelte/App.svelte
@@ -1,39 +1,27 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import '../../packages/u-progress'
-  import '../../packages/u-datalist'
-  import '../../packages/u-tags'
+  import './../../packages/u-progress'
+  import './../../packages/u-datalist'
+  import './../../packages/u-tags'
+  import './../../packages/u-tabs'
+  import Tabs from './components/Tabs.svelte'
 
-  let count: number = 0
   let value: string = ''
-  const increment = () => (count += 1)
-  const setValue = (content: string) => (value = content)
-
 </script>
+
 <main>
   <h1>Svelte + u-elements</h1>
-  <button on:click={increment}>
-    count is {count}
-  </button>
   <u-progress value="5" max="10">33%</u-progress>
   <br />
-  <input
-        list="my-list"
-        value={value}
-        on:input={() => {
-          setValue('-') // Need to set to something else first to force re-render overwrite
-          setValue('')
-        }}
-      />
-      <u-datalist id="my-list">
-        <u-option value="test-1">Test 1</u-option>
-        <u-option value="test-2">Test 2</u-option>
-        <u-option value="test-3">Test 3</u-option>
-      </u-datalist>
-      <u-tags on:tags={(event) => console.log(event.detail)}>
-        <data>Kokkos</data>
-        <data>Banan</data>
-        <data>Jordbær</data>
-        <input type="text" />
-      </u-tags>
+  <u-datalist id="my-list">
+    <u-option value="test-1">Test 1</u-option>
+    <u-option value="test-2">Test 2</u-option>
+    <u-option value="test-3">Test 3</u-option>
+  </u-datalist>
+  <u-tags on:tags={(event) => console.log(event.detail)}>
+    <data>Kokkos</data>
+    <data>Banan</data>
+    <data>Jordbær</data>
+    <input type="text" />
+  </u-tags>
+  <Tabs />
 </main>

--- a/frameworks/svelte/components/Tabs.svelte
+++ b/frameworks/svelte/components/Tabs.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import '../../../packages/u-tabs/dist/u-tabs'
+</script>
+
+<u-tabs>
+  <u-tablist>
+    <u-tab>Tab 1</u-tab>
+    <u-tab aria-selected="true">Tab 2</u-tab>
+    <u-tab>Tab 3</u-tab>
+  </u-tablist>
+  <u-tabpanel>Panel 1 with <a href="#">link</a></u-tabpanel>
+  <u-tabpanel>Panel 2 with <a href="#">link</a></u-tabpanel>
+  <u-tabpanel>Panel 3 with <a href="#">link</a></u-tabpanel>
+</u-tabs>
+
+<style>
+  u-tab {
+    padding: 0.5em;
+  }
+
+  u-tab[aria-selected='true'] {
+    border-bottom: 4px solid;
+  }
+
+  u-tabpanel {
+    padding: 1em;
+    border: 1px solid;
+  }
+</style>

--- a/frameworks/svelte/components/Tabs.svelte
+++ b/frameworks/svelte/components/Tabs.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
-  import '../../../packages/u-tabs/dist/u-tabs'
+  import "../../../packages/u-tabs/dist/u-tabs";
+  import selectedTabStore, { tabs } from "./store.js";
 </script>
 
 <u-tabs>
   <u-tablist>
-    <u-tab>Tab 1</u-tab>
-    <u-tab aria-selected="true">Tab 2</u-tab>
-    <u-tab>Tab 3</u-tab>
+    {#each tabs as tab (tab.name)}
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <u-tab
+        aria-selected={$selectedTabStore.name === tab.name}
+        on:click={() => selectedTabStore.set(tab)}
+        aria-controls={`tab-${tab.name}`}
+      >
+        {tab.name}
+      </u-tab>
+    {/each}
   </u-tablist>
-  <u-tabpanel>Panel 1 with <a href="#">link</a></u-tabpanel>
-  <u-tabpanel>Panel 2 with <a href="#">link</a></u-tabpanel>
-  <u-tabpanel>Panel 3 with <a href="#">link</a></u-tabpanel>
+  <u-tabpanel id={`tab-${tabs[0].name}`}> Panel 1 with ✨ </u-tabpanel>
+  <u-tabpanel id={`tab-${tabs[1].name}`}> Panel 2 with 🎖️ </u-tabpanel>
+  <u-tabpanel id={`tab-${tabs[2].name}`}> Panel 3 with ¿ </u-tabpanel>
 </u-tabs>
 
 <style>
@@ -18,12 +27,12 @@
     padding: 0.5em;
   }
 
-  u-tab[aria-selected='true'] {
+  u-tab[aria-selected="true"] {
     border-bottom: 4px solid;
   }
 
   u-tabpanel {
-    padding: 1em;
+    padding: 3em;
     border: 1px solid;
   }
 </style>

--- a/frameworks/svelte/components/Tabs.svelte
+++ b/frameworks/svelte/components/Tabs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import "../../../packages/u-tabs/dist/u-tabs";
   import selectedTabStore, { tabs } from "./store.js";
+  const selected = $selectedTabStore.name;
+  let showtada = false;
 </script>
 
 <u-tabs>
@@ -9,17 +11,42 @@
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <u-tab
-        aria-selected={$selectedTabStore.name === tab.name}
+        aria-selected={selected === tab.name}
         on:click={() => selectedTabStore.set(tab)}
         aria-controls={`tab-${tab.name}`}
       >
-        {tab.name}
+        {tab.name} - {selected === tab.name}
       </u-tab>
     {/each}
   </u-tablist>
   <u-tabpanel id={`tab-${tabs[0].name}`}> Panel 1 with ✨ </u-tabpanel>
   <u-tabpanel id={`tab-${tabs[1].name}`}> Panel 2 with 🎖️ </u-tabpanel>
   <u-tabpanel id={`tab-${tabs[2].name}`}> Panel 3 with ¿ </u-tabpanel>
+</u-tabs>
+
+<u-tabs>
+  <u-tablist>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <u-tab
+      aria-selected={showtada}
+      on:click={() => (showtada = true)}
+      aria-controls={`tab-tada`}
+    >
+      tada
+    </u-tab>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <u-tab
+      aria-selected={!showtada}
+      on:click={() => (showtada = false)}
+      aria-controls={`tab-meh`}
+    >
+      meh
+    </u-tab>
+  </u-tablist>
+  <u-tabpanel id={`tab-tada`}> Panel tada 🎉 </u-tabpanel>
+  <u-tabpanel id={`tab-meh`}> Panel meh 😥 </u-tabpanel>
 </u-tabs>
 
 <style>

--- a/frameworks/svelte/components/store.ts
+++ b/frameworks/svelte/components/store.ts
@@ -1,0 +1,36 @@
+import { writable } from "svelte/store";
+const localStorageKey = "selected-tabs-v2";
+
+const selectedTabStore = () => {
+  const { subscribe, set: setStore } = writable<Tab>(getInitialSelectedTab());
+
+  const set = (value: Tab) => {
+    setStore(value);
+    localStorage.setItem(localStorageKey, JSON.stringify(value));
+  };
+
+  return {
+    subscribe,
+    set,
+  };
+};
+
+export const tabs = [
+  { name: "Stars", icon: "*" },
+  { name: "Medals", icon: "🎖️" },
+  { name: "Help", icon: "?" },
+] as const;
+
+type Tab = (typeof tabs)[number];
+
+const getInitialSelectedTab = () => {
+  const userSelectedTab = JSON.parse(
+    localStorage.getItem(localStorageKey) ?? "null"
+  );
+  if (userSelectedTab != null) {
+    return userSelectedTab;
+  }
+  return tabs[0];
+};
+
+export default selectedTabStore();


### PR DESCRIPTION
Hi there, I have made two simple test-cases in svelte that breaks u-tabs. So this is sort of a bug-report, sort of a way of sharing my problem outside an issue.
I have not had the time to look into fixing anything as I'm not yet very familiar with the inner workings of u-elements.

This is the two cases:
1. localStorage backed tabs (remembers the last tab you visited)
   - tab[0] is always selected when page refreshes.
2. reactive variable (Not including all the other code that was the original reason for using a reactive variable here)
   - both tabs are selected when page loads
   - both tabpanels show up when the last tab is active
   
Both of these things works in u-tabs 0.0.3.