### PR TITLE
docs: expand demo code textarea in firefox

### DIFF
--- a/docs/.vitepress/theme/sandbox.vue
+++ b/docs/.vitepress/theme/sandbox.vue
@@ -41,7 +41,7 @@ watch(code, () => {
 <style>
   .demo { border-radius: 8px; border: 2px dashed var(--vp-c-divider); margin-block: .5em }
   .demo-code, .demo-view { box-sizing: border-box; display: block; max-width: 100%; min-width: 0 }
-  .demo-code { font: .875rem/1.5 var(--vp-font-family-mono); field-sizing: content; background: none; padding: .5em; resize: vertical; }
+  .demo-code { font: .875rem/1.5 var(--vp-font-family-mono); field-sizing: content; background: none; padding: .5em; resize: vertical; width: 100%; }
   .demo-view { border-bottom: inherit; min-height: 200px; padding: 1rem; margin: -2px }
   .demo-view :where(button,input) { all: revert }
 </style>


### PR DESCRIPTION
In Firefox, demo-code-textareas are a bit narrow, I guess they should fill the parent container? ☺️ 

<img width="768" height="354" alt="Skjermbilde 2026-03-04 kl  15 11 07" src="https://github.com/user-attachments/assets/60ad0f08-0577-4eb0-9e5e-34ce1b4527f4" />
